### PR TITLE
Add WPP Connect Env Vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ helm install my-jivas ./jvcloud/helm/jvcloud \
 | `optionalServices.wppconnect.storageClassName` | Storage class for WPPConnect | `gp2` | No |
 | `optionalServices.wppconnect.ingress.enabled` | Enable WPPConnect ingress | `true` | No |
 | `optionalServices.wppconnect.ingress.hostFormat` | Host format for WPPConnect | `{{ .Release.Namespace }}-wppconnect.{{ .Values.domain.name }}` | No |
+| `optionalServices.wppconnect.secretKey` | Secret key for WPPConnect (random if empty) | `""` | No |
 
 ### Autoscaling Configuration
 

--- a/jvcloud/helm/jivas/Chart.yaml
+++ b/jvcloud/helm/jivas/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jvcloud
 description: A Helm chart for deploying JIVAS application and its related services
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: "1.0.0"
 maintainers:
   - name: TrueSelph Inc

--- a/jvcloud/helm/jivas/templates/jivas/configmap.yaml
+++ b/jvcloud/helm/jivas/templates/jivas/configmap.yaml
@@ -49,3 +49,6 @@ data:
   TYPESENSE_PROTOCOL: {{ .Values.optionalServices.typesense.protocol | quote }}
   TYPESENSE_CONNECTION_TIMEOUT_SECONDS: {{ .Values.optionalServices.typesense.connectionTimeoutSeconds | quote }}
   {{- end }}
+  {{- if .Values.optionalServices.wppconnect.enabled }}
+  WPP_API_URL: "https://{{ tpl .Values.optionalServices.wppconnect.ingress.hostFormat . }}"
+  {{- end }}

--- a/jvcloud/helm/jivas/templates/jivas/deployment.yaml
+++ b/jvcloud/helm/jivas/templates/jivas/deployment.yaml
@@ -159,6 +159,18 @@ spec:
                   name: jivas-config
                   key: TYPESENSE_CONNECTION_TIMEOUT_SECONDS
             {{- end }}
+            {{- if .Values.optionalServices.wppconnect.enabled }}
+            - name: WPP_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: jivas-config
+                  key: WPP_API_URL
+            - name: WPP_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: wppconnect-secrets
+                  key: SECRET_KEY
+            {{- end }}
           volumeMounts:
             - name: jivas-data
               mountPath: /app/.jvdata


### PR DESCRIPTION
## Type of Change
- [ ] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [x] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

## Summary
This pull request includes updates to the Helm chart and deployment templates for the JIVAS application. The changes add support for the WPPConnect service by introducing new configuration and environment variable options, along with a version bump to the Helm chart.

## Description
### Helm Chart Update
- Updated `Chart.yaml` version from `0.0.2` to `0.0.3` to reflect changes in deployment configuration.

### WPPConnect Configuration Support
- **ConfigMap Updates**:
  - Modified `configmap.yaml` to include a new `WPP_API_URL` configuration key when WPPConnect is enabled.

- **Deployment Spec Updates**:
  - Updated `deployment.yaml` to include environment variables for:
    - `WPP_API_URL` from `jivas-config` ConfigMap
    - `WPP_MASTER_KEY` from `wppconnect-secrets` Secret
  - These are conditionally applied only when the WPPConnect service is enabled.

## Changes Made
1. Bumped Helm chart version to `0.0.3`.
2. Added `WPP_API_URL` to the ConfigMap template.
3. Injected `WPP_API_URL` and `WPP_MASTER_KEY` into the deployment environment variables.
