### PR TITLE
Increase Jivas Pod Resource Limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ helm install my-jivas ./jvcloud/helm/jvcloud \
 | Parameter | Description | Default | Required |
 |-----------|-------------|---------|----------|
 | `jivas.resources.requests.memory` | Memory request for JIVAS | `512Mi` | No |
-| `jivas.resources.requests.cpu` | CPU request for JIVAS | `250m` | No |
+| `jivas.resources.requests.cpu` | CPU request for JIVAS | `1000m` | No |
 | `jivas.resources.limits.memory` | Memory limit for JIVAS | `1Gi` | No |
-| `jivas.resources.limits.cpu` | CPU limit for JIVAS | `500m` | No |
+| `jivas.resources.limits.cpu` | CPU limit for JIVAS | `1500m` | No |
 
 ### Optional Services
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,9 +132,9 @@ helm install my-jivas ./jvcloud/helm/jvcloud \
 | Parameter | Description | Default | Required |
 |-----------|-------------|---------|----------|
 | `jivas.resources.requests.memory` | Memory request for JIVAS | `512Mi` | No |
-| `jivas.resources.requests.cpu` | CPU request for JIVAS | `250m` | No |
+| `jivas.resources.requests.cpu` | CPU request for JIVAS | `1000m` | No |
 | `jivas.resources.limits.memory` | Memory limit for JIVAS | `1Gi` | No |
-| `jivas.resources.limits.cpu` | CPU limit for JIVAS | `500m` | No |
+| `jivas.resources.limits.cpu` | CPU limit for JIVAS | `1500m` | No |
 
 ### Optional Services
 

--- a/jvcloud/helm/jivas/Chart.yaml
+++ b/jvcloud/helm/jivas/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jvcloud
 description: A Helm chart for deploying JIVAS application and its related services
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: "1.0.0"
 maintainers:
   - name: TrueSelph Inc

--- a/jvcloud/helm/jivas/values.yaml
+++ b/jvcloud/helm/jivas/values.yaml
@@ -49,10 +49,10 @@ jivas:
   resources:
     requests:
       memory: "512Mi"
-      cpu: "250m"
+      cpu: "1000m"
     limits:
       memory: "1Gi"
-      cpu: "500m"
+      cpu: "1500m"
   probes:
     liveness:
       path: "/healthz"


### PR DESCRIPTION
## Type of Change
- [ ] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [x] 🔄 Refactor
- [x] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

## Summary
This pull request updates the resource requests and limits for the JIVAS component in both the Helm chart and related documentation. The goal is to allocate more CPU resources to better reflect the application's runtime requirements.

## Description
### Resource Adjustments
- Increased the default CPU **request** from `250m` to `1000m`.
- Increased the CPU **limit** from `500m` to `1500m`.

### Affected Files
- `README.md`: Updated the example resource settings to match the new values.
- `docs/README.md`: Reflected the same resource updates in the deployment guide.
- `jvcloud/helm/jivas/values.yaml`: Applied the new CPU request and limit values in the Helm chart defaults.

## Changes Made
1. Updated CPU resource values for JIVAS in `values.yaml`.
2. Reflected these changes in both public-facing and internal documentation.