### PR TITLE
Reuse Redis Password on update

### DIFF
--- a/jvcloud/helm/jivas/Chart.yaml
+++ b/jvcloud/helm/jivas/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jvcloud
 description: A Helm chart for deploying JIVAS application and its related services
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "1.0.0"
 maintainers:
   - name: TrueSelph Inc

--- a/jvcloud/helm/jivas/templates/jivas/redis.yaml
+++ b/jvcloud/helm/jivas/templates/jivas/redis.yaml
@@ -7,7 +7,22 @@ metadata:
     {{- include "jivas.labels" . | nindent 4 }}
 type: Opaque
 data:
-  REDIS_PASSWORD: {{ default (randAlphaNum 32) .Values.redis.password | b64enc }}
+  {{- $redisPasswordKey := "REDIS_PASSWORD" }}
+  {{- $redisPassword := "" }}
+  
+  {{- /* Try to get the existing secret password */ -}}
+  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace "redis-secrets") }}
+  {{- if and $existingSecret $existingSecret.data $existingSecret.data.REDIS_PASSWORD }}
+    {{- /* Use the existing password if it exists */ -}}
+    {{- $redisPassword = $existingSecret.data.REDIS_PASSWORD }}
+  {{- else if .Values.redis.password }}
+    {{- /* Use the specified password if provided */ -}}
+    {{- $redisPassword = (.Values.redis.password | b64enc) }}
+  {{- else }}
+    {{- /* Generate a new random password as last resort */ -}}
+    {{- $redisPassword = (randAlphaNum 32 | b64enc) }}
+  {{- end }}
+  REDIS_PASSWORD: {{ $redisPassword }}
 ---
 # Redis Deployment
 apiVersion: apps/v1


### PR DESCRIPTION
## Type of Change
- [ ] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [x] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

## Summary
This pull request updates the Helm chart for the JIVAS application, including versioning improvements and enhanced Redis password handling to better manage secrets for the application.

## Description
### Version Updates
- Updated the chart version in `Chart.yaml` from `0.0.7` to `0.0.8` to reflect recent changes and improvements.

### Secret Management Improvements
- Enhanced Redis password management in the `redis.yaml` template:
  - Checks for an existing secret password.
  - Falls back to a password provided in values if available.
  - Generates a new random password if no other options are found.

## Changes Made
1. Bumped Helm chart version to `0.0.8` in `Chart.yaml`.
2. Improved Redis password management logic in `redis.yaml` to support multiple password sources (existing secret, value, or random generation).