### PR TITLE
Preserve Secrets on Helm Update

### DIFF
--- a/jvcloud/helm/jivas/Chart.yaml
+++ b/jvcloud/helm/jivas/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: jvcloud
 description: A Helm chart for deploying JIVAS application and its related services
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: "1.0.0"
 maintainers:
   - name: TrueSelph Inc

--- a/jvcloud/helm/jivas/templates/jivas/configmap.yaml
+++ b/jvcloud/helm/jivas/templates/jivas/configmap.yaml
@@ -53,5 +53,5 @@ data:
   TYPESENSE_CONNECTION_TIMEOUT_SECONDS: {{ .Values.optionalServices.typesense.connectionTimeoutSeconds | quote }}
   {{- end }}
   {{- if .Values.optionalServices.wppconnect.enabled }}
-  WPP_API_URL: "https://{{ tpl .Values.optionalServices.wppconnect.ingress.hostFormat . }}"
+  WPP_API_URL: "https://{{ tpl .Values.optionalServices.wppconnect.ingress.hostFormat . }}/api"
   {{- end }}

--- a/jvcloud/helm/jivas/templates/jivas/secrets.yaml
+++ b/jvcloud/helm/jivas/templates/jivas/secrets.yaml
@@ -14,13 +14,56 @@ metadata:
     {{- include "jivas.labels" . | nindent 4 }}
 type: Opaque
 data:
-  JIVAS_PASSWORD: {{ default (include "jivas.randomPassword" .) .Values.jivas.secrets.password | b64enc }}
-  JIVAS_WEBHOOK_SECRET_KEY: {{ default (include "jivas.randomPassword" .) .Values.jivas.secrets.webhookSecretKey | b64enc }}
-  JIVAS_TOKEN_SECRET: {{ default (include "jivas.randomPassword" .) .Values.jivas.secrets.tokenSecret | b64enc }}
-  TOKEN_SECRET: {{ default (include "jivas.randomTokenSecret" .) .Values.jivas.secrets.plainTokenSecret | b64enc }}
-{{- if eq .Values.jivas.config.fileInterface "s3" }}
+  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace "jivas-secrets") }}
+  
+  {{- /* JIVAS_PASSWORD */ -}}
+  {{- $jivasPassword := "" }}
+  {{- if and $existingSecret $existingSecret.data $existingSecret.data.JIVAS_PASSWORD }}
+    {{- $jivasPassword = $existingSecret.data.JIVAS_PASSWORD }}
+  {{- else if .Values.jivas.secrets.password }}
+    {{- $jivasPassword = (.Values.jivas.secrets.password | b64enc) }}
+  {{- else }}
+    {{- $jivasPassword = (randAlphaNum 32 | b64enc) }}
+  {{- end }}
+  
+  {{- /* JIVAS_WEBHOOK_SECRET_KEY */ -}}
+  {{- $jivasWebhookSecretKey := "" }}
+  {{- if and $existingSecret $existingSecret.data $existingSecret.data.JIVAS_WEBHOOK_SECRET_KEY }}
+    {{- $jivasWebhookSecretKey = $existingSecret.data.JIVAS_WEBHOOK_SECRET_KEY }}
+  {{- else if .Values.jivas.secrets.webhookSecretKey }}
+    {{- $jivasWebhookSecretKey = (.Values.jivas.secrets.webhookSecretKey | b64enc) }}
+  {{- else }}
+    {{- $jivasWebhookSecretKey = (randAlphaNum 32 | b64enc) }}
+  {{- end }}
+  
+  {{- /* JIVAS_TOKEN_SECRET */ -}}
+  {{- $jivasTokenSecret := "" }}
+  {{- if and $existingSecret $existingSecret.data $existingSecret.data.JIVAS_TOKEN_SECRET }}
+    {{- $jivasTokenSecret = $existingSecret.data.JIVAS_TOKEN_SECRET }}
+  {{- else if .Values.jivas.secrets.tokenSecret }}
+    {{- $jivasTokenSecret = (.Values.jivas.secrets.tokenSecret | b64enc) }}
+  {{- else }}
+    {{- $jivasTokenSecret = (randAlphaNum 32 | b64enc) }}
+  {{- end }}
+  
+  {{- /* TOKEN_SECRET */ -}}
+  {{- $tokenSecret := "" }}
+  {{- if and $existingSecret $existingSecret.data $existingSecret.data.TOKEN_SECRET }}
+    {{- $tokenSecret = $existingSecret.data.TOKEN_SECRET }}
+  {{- else if .Values.jivas.secrets.plainTokenSecret }}
+    {{- $tokenSecret = (.Values.jivas.secrets.plainTokenSecret | b64enc) }}
+  {{- else }}
+    {{- $tokenSecret = (randAlphaNum 50 | b64enc) }}
+  {{- end }}
+  
+  JIVAS_PASSWORD: {{ $jivasPassword }}
+  JIVAS_WEBHOOK_SECRET_KEY: {{ $jivasWebhookSecretKey }}
+  JIVAS_TOKEN_SECRET: {{ $jivasTokenSecret }}
+  TOKEN_SECRET: {{ $tokenSecret }}
+  
+  {{- if eq .Values.jivas.config.fileInterface "s3" }}
   JIVAS_S3_BUCKET_NAME: {{ .Values.jivas.config.s3.bucketName | b64enc }}
   JIVAS_S3_REGION_NAME: {{ .Values.jivas.config.s3.regionName | b64enc }}
   JIVAS_S3_ACCESS_KEY_ID: {{ .Values.jivas.config.s3.accessKeyId | b64enc }}
   JIVAS_S3_SECRET_ACCESS_KEY: {{ .Values.jivas.config.s3.secretAccessKey | b64enc }}
-{{- end }}
+  {{- end }}

--- a/jvcloud/helm/jivas/templates/optional/typesense.yaml
+++ b/jvcloud/helm/jivas/templates/optional/typesense.yaml
@@ -8,7 +8,21 @@ metadata:
     {{- include "jivas.labels" . | nindent 4 }}
 type: Opaque
 data:
-  TYPESENSE_API_KEY: {{ default (randAlphaNum 32) .Values.optionalServices.typesense.apiKey | b64enc }}
+  {{- $typesenseApiKey := "" }}
+  
+  {{- /* Try to get the existing secret API key */ -}}
+  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace "typesense-secrets") }}
+  {{- if and $existingSecret $existingSecret.data $existingSecret.data.TYPESENSE_API_KEY }}
+    {{- /* Use the existing API key if it exists */ -}}
+    {{- $typesenseApiKey = $existingSecret.data.TYPESENSE_API_KEY }}
+  {{- else if .Values.optionalServices.typesense.apiKey }}
+    {{- /* Use the specified API key if provided */ -}}
+    {{- $typesenseApiKey = (.Values.optionalServices.typesense.apiKey | b64enc) }}
+  {{- else }}
+    {{- /* Generate a new random API key as last resort */ -}}
+    {{- $typesenseApiKey = (randAlphaNum 32 | b64enc) }}
+  {{- end }}
+  TYPESENSE_API_KEY: {{ $typesenseApiKey }}
 ---
 # Then create the StatefulSet
 apiVersion: apps/v1

--- a/jvcloud/helm/jivas/templates/optional/wppconnect.yaml
+++ b/jvcloud/helm/jivas/templates/optional/wppconnect.yaml
@@ -8,7 +8,21 @@ metadata:
     {{- include "jivas.labels" . | nindent 4 }}
 type: Opaque
 data:
-  SECRET_KEY: {{ default (randAlphaNum 32) .Values.optionalServices.wppconnect.secretKey | b64enc }}
+  {{- $secretKey := "" }}
+  
+  {{- /* Try to get the existing secret key */ -}}
+  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace "wppconnect-secrets") }}
+  {{- if and $existingSecret $existingSecret.data $existingSecret.data.SECRET_KEY }}
+    {{- /* Use the existing secret key if it exists */ -}}
+    {{- $secretKey = $existingSecret.data.SECRET_KEY }}
+  {{- else if .Values.optionalServices.wppconnect.secretKey }}
+    {{- /* Use the specified secret key if provided */ -}}
+    {{- $secretKey = (.Values.optionalServices.wppconnect.secretKey | b64enc) }}
+  {{- else }}
+    {{- /* Generate a new random secret key as last resort */ -}}
+    {{- $secretKey = (randAlphaNum 32 | b64enc) }}
+  {{- end }}
+  SECRET_KEY: {{ $secretKey }}
 ---
 # Then create the StatefulSet
 apiVersion: apps/v1


### PR DESCRIPTION
## Type of Change
- [ ] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [x] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

## Summary
This pull request introduces improvements to secret management and updates to configuration URLs in the Helm chart for the Jivas application. The key changes enhance security by dynamically managing secrets and refining the WPPConnect API URL configuration.

## Description
### Secret Management Enhancements
- **Dynamic Secret Handling for Jivas**:
  - Updated `secrets.yaml` to:
    - Reuse existing secrets for `JIVAS_PASSWORD`, `JIVAS_WEBHOOK_SECRET_KEY`, `JIVAS_TOKEN_SECRET`, and `TOKEN_SECRET` if available.
    - Use configured values or generate new random secrets as fallbacks.
  
- **Dynamic Secret Handling for Typesense**:
  - Updated `typesense.yaml` to check for and reuse the `TYPESENSE_API_KEY` secret, falling back to a configured value or generating a new random key if necessary.

- **Dynamic Secret Handling for WPPConnect**:
  - Modified `wppconnect.yaml` to reuse the `SECRET_KEY` secret, with fallbacks to a configured value or new random key.

### Configuration Updates
- **Updated WPPConnect API URL**:
  - Changed the `WPP_API_URL` in `configmap.yaml` to include the `/api` suffix, ensuring compatibility with the expected API endpoint format.

## Changes Made
1. Enhanced secret management for Jivas, Typesense, and WPPConnect with dynamic handling and fallbacks.
2. Updated `WPP_API_URL` to include the `/api` suffix for proper API endpoint configuration.
